### PR TITLE
add output redirect route for workflow playbook nodes

### DIFF
--- a/awx/ui/client/features/output/legacy.route.js
+++ b/awx/ui/client/features/output/legacy.route.js
@@ -1,4 +1,4 @@
-function LegacyRedirect ($stateRegistry) {
+function LegacyRedirect ($http, $stateRegistry) {
     const destination = 'output';
     const routes = [
         {
@@ -66,11 +66,35 @@ function LegacyRedirect ($stateRegistry) {
                 return { state: 'schedules.edit', params: { schedule_id, schedule_search } };
             }
         },
+        {
+            name: 'workflowPlaybookNodeRedirect',
+            url: '/workflow_node_playbook_results/:id',
+            redirectTo: (trans) => {
+                // The workflow job viewer uses this route for playbook job nodes. The provided id
+                // is used to lookup the corresponding unified job, which is then inspected to
+                // determine if we need to redirect to a split (workflow) job or a playbook job.
+                const { id } = trans.params();
+                const endpoint = '/api/v2/unified_jobs/';
+
+                return $http.get(endpoint, { params: { id } })
+                    .then(({ data }) => {
+                        const { results } = data;
+                        const [obj] = results;
+
+                        if (obj && obj.type === 'workflow_job') {
+                            return { state: 'workflowResults', params: { id } };
+                        }
+
+                        return { state: destination, params: { type: 'playbook', id } };
+                    })
+                    .catch(() => ({ state: 'dashboard' }));
+            }
+        },
     ];
 
     routes.forEach(state => $stateRegistry.register(state));
 }
 
-LegacyRedirect.$inject = ['$stateRegistry'];
+LegacyRedirect.$inject = ['$http', '$stateRegistry'];
 
 export default LegacyRedirect;

--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -769,7 +769,7 @@ export default ['$state','moment', '$timeout', '$window', '$filter', 'Rest', 'Ge
                             let href = "";
                             if (d.job) {
                                 if(d.job.type === 'job') {
-                                    href = `/#/jobs/playbook/${d.job.id}`;
+                                    href = `/#/workflow_node_playbook_results/${d.job.id}`;
                                 }
                                 else if(d.job.type === 'inventory_update') {
                                     href = `/#/jobs/inventory/${d.job.id}`;
@@ -1070,7 +1070,7 @@ export default ['$state','moment', '$timeout', '$window', '$filter', 'Rest', 'Ge
                                     let href = "";
                                     if (d.job) {
                                         if(d.job.type === 'job') {
-                                            href = `/#/jobs/playbook/${d.job.id}`;
+                                            href = `/#/workflow_node_playbook_results/${d.job.id}`;
                                         }
                                         else if(d.job.type === 'inventory_update') {
                                             href = `/#/jobs/inventory/${d.job.id}`;


### PR DESCRIPTION
##### SUMMARY
adds a route for the workflow viewer to use: `/#/workflow_node_playbook_results/:id`. This route looks up the unified job for the given id and then redirects to the workflow or playbook job results page depending on the job type. 

